### PR TITLE
Be able to set status position

### DIFF
--- a/lua/gitabra/git_status.lua
+++ b/lua/gitabra/git_status.lua
@@ -193,7 +193,7 @@ local function patch_infos()
 end
 
 local function setup_window()
-  vim.cmd(":topleft vsplit")
+  vim.cmd(":" .. vim.g.gitabra_status_window_pos)
   local win = api.nvim_get_current_win()
   vim.wo[win].number = false
   vim.wo[win].relativenumber = false

--- a/plugin/gitabra.vim
+++ b/plugin/gitabra.vim
@@ -1,1 +1,5 @@
-	command Gitabra lua require'gitabra'.gitabra_status()
+if !exists('g:gitabra_status_window_pos')
+  let g:gitabra_status_window_pos = 'botright vsplit'
+endif
+
+command Gitabra lua require'gitabra'.gitabra_status()


### PR DESCRIPTION
Lets you set `g:gitabra_status_window_pos` to act as window modifiers to control where gitabra's status buffer opens.

Also I propose `botright vsplit` as a better default, cause I think the right side of the screen is also a magit default choice.