### PR TITLE
fix: avoid URL.parse error use with coc.nvim

### DIFF
--- a/lua/gitabra/git_status.lua
+++ b/lua/gitabra/git_status.lua
@@ -292,7 +292,7 @@ local function setup_keybinds(bufnr)
   set_keymap('n', 'k', '<cmd>lua require("gitabra.git_status").prev_line()<cr>', opts)
 end
 
-local status_buf_name = "gitabra:////gitabra_status"
+local status_buf_name = "gitabra://gitabra_status"
 
 -- Looks through all available buffers and returns the gitabra status buffer if found
 -- This helps us recover the bufnr if it becomes lost. This usually happens when the


### PR DESCRIPTION
> Error: [UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash char
acters ("//")

This error occur in [URL.parse](https://github.com/Microsoft/vscode-uri)
